### PR TITLE
Fix: Allow for publication.yaml to have only title, without subtitle

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/manifest.js
@@ -89,6 +89,8 @@ module.exports = (eleventyConfig) => {
       return `${title}: ${subtitle} ${readingLine}`
     } else if (subtitle) {
       return `${title}: ${subtitle}`
+    } else {
+      return `${title}`
     }
   }
 


### PR DESCRIPTION
### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?
n/a


### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.
Allowing to have only one title for a book/publication and omitting subtitle is an important aspect of fiction books.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.


### Does this pull request necessitate changes to Quire's documentation?
No.


### Include screenshots of before/after if applicable.



### Additional Comments

