### PR TITLE
Fix epub format css file relative url for pages

### DIFF
--- a/packages/11ty/_plugins/transforms/outputs/epub/layout.js
+++ b/packages/11ty/_plugins/transforms/outputs/epub/layout.js
@@ -10,7 +10,7 @@ module.exports = ({ body, language, title }) => {
     <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="${language}">
       <head>
         <meta charset="utf-8" />
-        <link rel="stylesheet" type="text/css" href="_assets/epub.css" />
+        <link rel="stylesheet" type="text/css" href="./_assets/epub.css" />
         ${titleElement}
         ${stylesheets}
       </head>


### PR DESCRIPTION
### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?
n/a


### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.
Current epub generated are not passing epubcheck by Epub 3.3 format, because of non-right relative url to css. This PR fixes it.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.
n/a

### Does this pull request necessitate changes to Quire's documentation?
n/a


### Include screenshots of before/after if applicable.
n/a


### Additional Comments
n/a
