### PR TITLE
Fix: Allow not specifying any figures for publication

### DIFF
--- a/packages/11ty/_plugins/figures/index.js
+++ b/packages/11ty/_plugins/figures/index.js
@@ -14,6 +14,11 @@ module.exports = function (eleventyConfig, options = {}) {
     const config = iiifConfig(eleventyConfig)
     const figureFactory = new FigureFactory(config)
 
+    if (!eleventyConfig.globalData.figures || !eleventyConfig.globalData.figures.figure_list) {
+      logger.error('The figure list is not defined or is null.')
+      return
+    }
+
     const { figure_list: figureList } = eleventyConfig.globalData.figures
 
     const figures = await Promise.all(


### PR DESCRIPTION
### Checklist 

Please put an `X` within the brackets that apply `[X]`. 

- [X] I have read the [CONTRIBUTING.md](https://github.com/thegetty/quire/blob/main/CONTRIBUTING.md) file

- [X] I have made my changes in a new branch and not directly in the main branch

- [X] This pull request is ready for final review by the Quire team


### Is this pull request related to an open issue? If so, what is the issue number?
n/a


### Please briefly describe the goal of this pull request and how it may impact Quire's functionality.
Allow to not specify figures in figures.yaml, as not needed for fiction literature.

### Please describe the changes you made, and call out any details you think are particularly relevant for the Quire team to note in their review.
n/a

### Does this pull request necessitate changes to Quire's documentation?
n/a


### Include screenshots of before/after if applicable.
n/a


### Additional Comments
n/a
